### PR TITLE
spring-boot 3.1 and hibernate 6.2 upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+0.0.9-SNAPSHOT:
+- updated to spring-boot 3.1 and hibernate 6.2
+- generation of full-parametric SQL queries (previous version generated mixed parametric / static queries, which required messing with Hibernate internals and moreover could lead to SQL injections)
+- updated postgresql testcontainer to version 15

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.alexliesenfeld</groupId>
     <artifactId>querydsl-jpa-postgres-json</artifactId>
-    <version>0.0.8-SNAPSHOT</version>
+    <version>0.0.9-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Querydsl extension for using PostgreSQL JSON types with JPA</description>
@@ -16,11 +16,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <querydsl.version>5.0.0</querydsl.version>
-        <!-- spring boot 3.0.6 versions -->
-        <hibernate.version>6.1.7.Final</hibernate.version>
-        <lombok.version>1.18.26</lombok.version>
-        <jackson.version>2.14.2</jackson.version>
-        <hypersistence.version>3.3.2</hypersistence.version>
+        <!-- spring boot 3.1.2 versions -->
+        <hibernate.version>6.2.6.Final</hibernate.version>
+        <lombok.version>1.18.28</lombok.version>
+        <jackson.version>2.15.2</jackson.version>
+        <hypersistence.version>3.5.1</hypersistence.version>
+        <spring-boot.version>3.1.2</spring-boot.version>
     </properties>
 
     <dependencies>
@@ -58,35 +59,29 @@
             <optional>true</optional>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-dependencies</artifactId>-->
-<!--            <version>3.0.6</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.0.6</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>3.0.6</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
-            <version>3.0.6</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.0.6</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -103,26 +98,6 @@
             <scope>test</scope>
         </dependency>
 
-
-        <!-- Query dsl -->
-<!--        <dependency>-->
-<!--            <groupId>com.querydsl</groupId>-->
-<!--            <artifactId>querydsl-core</artifactId>-->
-<!--            <version>${querydsl.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>com.querydsl</groupId>-->
-<!--            <artifactId>querydsl-sql</artifactId>-->
-<!--            <version>${querydsl.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>com.querydsl</groupId>-->
-<!--            <artifactId>querydsl-sql-spring</artifactId>-->
-<!--            <version>${querydsl.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
@@ -153,7 +128,7 @@
 
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -222,17 +197,6 @@
                 <artifactId>apt-maven-plugin</artifactId>
                 <version>1.1.3</version>
                 <executions>
-<!--                    <execution>-->
-<!--                        <id>generate-source-entities</id>-->
-<!--                        <phase>generate-sources</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>process</goal>-->
-<!--                        </goals>-->
-<!--                        <configuration>-->
-<!--                            <outputDirectory>target/generated-sources/java</outputDirectory>-->
-<!--                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
                     <execution>
                         <id>generate-test-entities</id>
                         <phase>generate-test-sources</phase>

--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/PostgreSQLJsonDialect.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/PostgreSQLJsonDialect.java
@@ -2,9 +2,10 @@ package com.github.alexliesenfeld.querydsl.jpa.hibernate;
 
 import com.github.alexliesenfeld.querydsl.jpa.hibernate.functions.types.*;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonBinaryJdbcTypeDescriptor;
+
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgresPlusDialect;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.service.ServiceRegistry;
 
 import java.sql.Types;
@@ -25,26 +26,26 @@ public class PostgreSQLJsonDialect extends PostgresPlusDialect {
 
 
   @Override
-  public void initializeFunctionRegistry(QueryEngine queryEngine) {
-    super.initializeFunctionRegistry(queryEngine);
+  public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+    super.initializeFunctionRegistry(functionContributions);
 
-    queryEngine.getSqmFunctionRegistry().register("hql_json_text", new TextJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_int", new IntJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_float", new FloatJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_double", new DoubleJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_long", new LongJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_short", new ShortJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_json_bool", new BoolJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_text", new TextJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_int", new IntJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_float", new FloatJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_double", new DoubleJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_long", new LongJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_short", new ShortJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_json_bool", new BoolJsonSQLFunction());
 
-    queryEngine.getSqmFunctionRegistry().register("hql_json_" + "array_length", new LongJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_jsonb_" + "array_length", new LongJsonSQLFunction().setJsonb(true));
+    functionContributions.getFunctionRegistry().register("hql_json_" + "array_length", new LongJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_jsonb_" + "array_length", new LongJsonSQLFunction().setJsonb(true));
 
-    queryEngine.getSqmFunctionRegistry().register("hql_json_" + "typeof", new LongJsonSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_jsonb_" + "typeof", new LongJsonSQLFunction().setJsonb(true));
+    functionContributions.getFunctionRegistry().register("hql_json_" + "typeof", new LongJsonSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_jsonb_" + "typeof", new LongJsonSQLFunction().setJsonb(true));
 
 
-    queryEngine.getSqmFunctionRegistry().register("hql_json_contains", new JsonContainsSQLFunction());
-    queryEngine.getSqmFunctionRegistry().register("hql_jsonb_contains", new JsonContainsSQLFunction().setJsonb(true));
+    functionContributions.getFunctionRegistry().register("hql_json_contains", new JsonContainsSQLFunction());
+    functionContributions.getFunctionRegistry().register("hql_jsonb_contains", new JsonContainsSQLFunction().setJsonb(true));
 
   }
 

--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/AbstractJsonSQLFunction.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/AbstractJsonSQLFunction.java
@@ -3,12 +3,9 @@ package com.github.alexliesenfeld.querydsl.jpa.hibernate.functions;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.AssertionFailure;
-import org.hibernate.query.spi.QueryParameterBinding;
-import org.hibernate.query.spi.QueryParameterImplementor;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
 import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
-import org.hibernate.query.sqm.sql.internal.SqmParameterInterpretation;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
@@ -17,9 +14,7 @@ import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.update.Assignable;
 import org.hibernate.type.JavaObjectType;
 
-import java.lang.reflect.Field;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * @author <a href=http://github.com/wenerme>wener</a>
@@ -35,44 +30,16 @@ public abstract class AbstractJsonSQLFunction
   static int maximalArgumentCount = 64;
   protected boolean jsonb = true;
 
-  static Field queryParamField;
-  static Field queryParamBindingResolverField;
 
-  static {
-    try {
-      queryParamField = SqmParameterInterpretation.class.getDeclaredField("queryParameter");
-      queryParamField.setAccessible(true);
-      queryParamBindingResolverField = SqmParameterInterpretation.class.getDeclaredField("queryParameterBindingResolver");
-      queryParamBindingResolverField.setAccessible(true);
-    } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
+  public void buildPath(SqlAppender sb,  List<? extends SqlAstNode>  arguments, SqlAstTranslator<?> walker) {
+    buildPath(sb, arguments, 0, arguments.size(), walker);
   }
 
-
-  protected Object getSqmParameterInterpretation(Object arg) {
-    if (!(arg instanceof SqmParameterInterpretation))
-      throw new AssertionFailure("Not an implemented parameter type");
-    try {
-      Object queryParam = queryParamField.get(arg);
-      Object queryParamBindingResolver = queryParamBindingResolverField.get(arg);
-
-      QueryParameterBinding<?> binding = ((Function<QueryParameterImplementor<?>, QueryParameterBinding<?>>) queryParamBindingResolver).apply((QueryParameterImplementor<?>) queryParam);
-      return binding.getBindValue();
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
+  public void buildPath(SqlAppender sb, List<? extends SqlAstNode>  arguments, int n, SqlAstTranslator<?> walker) {
+    buildPath(sb, arguments, 0, n < 0 ? arguments.size() + n : n, walker);
   }
 
-  public void buildPath(SqlAppender sb, List arguments) {
-    buildPath(sb, arguments, 0, arguments.size());
-  }
-
-  public void buildPath(SqlAppender sb, List arguments, int n) {
-    buildPath(sb, arguments, 0, n < 0 ? arguments.size() + n : n);
-  }
-
-  public void buildPath(SqlAppender sb, List arguments, int from, int to) {
+  public void buildPath(SqlAppender sb, List<? extends SqlAstNode>  arguments, int from, int to, SqlAstTranslator<?> walker) {
     Object arg = arguments.get(from);
 
     if (!(arg instanceof Assignable))
@@ -83,14 +50,11 @@ public abstract class AbstractJsonSQLFunction
 
     for (int i = to - 1; i >= from + 1; i--) {
       sb.append("->");
-
-      sb.append("'");
-      sb.append(arg == null ? "null" : getSqmParameterInterpretation(arguments.get(i)).toString());
-      sb.append("'");
+      arguments.get(i).accept(walker);
     }
   }
 
-  public AbstractJsonSQLFunction() {
+  protected AbstractJsonSQLFunction() {
     super(
             "sql",
             StandardArgumentsValidators.between(minimalArgumentCount, maximalArgumentCount),
@@ -108,17 +72,17 @@ public abstract class AbstractJsonSQLFunction
           Boolean respectNulls,
           Boolean fromFirst,
           SqlAstTranslator<?> walker) {
-    doRender(sqlAppender, sqlAstArguments);
+    doRender(sqlAppender, sqlAstArguments, walker);
   }
 
   public void render(
           SqlAppender sqlAppender,
           List<? extends SqlAstNode> arguments,
           SqlAstTranslator<?> walker) {
-    doRender(sqlAppender, arguments);
+    doRender(sqlAppender, arguments, walker);
   }
 
-  protected abstract void doRender(SqlAppender sb, List arguments);
+  protected abstract void doRender(SqlAppender sb, List<? extends SqlAstNode> arguments, SqlAstTranslator<?> walker);
 
   @Override
   public String getArgumentListSignature() {

--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/AbstractTypedJsonFunction.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/AbstractTypedJsonFunction.java
@@ -1,6 +1,8 @@
 package com.github.alexliesenfeld.querydsl.jpa.hibernate.functions;
 
+import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 
 import java.util.List;
 
@@ -12,22 +14,19 @@ import java.util.List;
 public abstract class AbstractTypedJsonFunction extends AbstractJsonSQLFunction {
     private final String conversion;
 
-    public AbstractTypedJsonFunction(String conversion) {
+    protected AbstractTypedJsonFunction(String conversion) {
         this.conversion = conversion;
     }
 
-    protected void doRender(SqlAppender sb, List arguments) {
+    protected void doRender(SqlAppender sb, List<? extends SqlAstNode> arguments, SqlAstTranslator<?> walker) {
         if (conversion != null) {
             sb.append('(');
         }
 
-        Object arg = arguments.get(arguments.size() - 1);
-        buildPath(sb, arguments, -1);
+        buildPath(sb, arguments, -1, walker);
         sb.append("->>");
 
-        sb.append("'");
-        sb.append(arg == null ? "null" : getSqmParameterInterpretation(arg).toString());
-        sb.append("'");
+        arguments.get(arguments.size() - 1).accept(walker);
 
         if (conversion != null) {
             sb.append(")::");

--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/JsonFunction.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/JsonFunction.java
@@ -2,7 +2,10 @@ package com.github.alexliesenfeld.querydsl.jpa.hibernate.functions;
 
 import lombok.Getter;
 import lombok.Setter;
+
+import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.type.Type;
 
 import java.util.List;
@@ -24,10 +27,10 @@ public class JsonFunction extends AbstractJsonSQLFunction {
     super();
   }
 
-  protected void doRender(SqlAppender sb, List arguments) {
+  protected void doRender(SqlAppender sb, List<? extends SqlAstNode> arguments, SqlAstTranslator<?> walker) {
     sb.append(isJsonb() ? jsonbFunctionName : jsonFunctionName);
     sb.append('(');
-    buildPath(sb, arguments);
+    buildPath(sb, arguments, walker);
     sb.append(')');
   }
 

--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/types/JsonContainsSQLFunction.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/types/JsonContainsSQLFunction.java
@@ -1,7 +1,10 @@
 package com.github.alexliesenfeld.querydsl.jpa.hibernate.functions.types;
 
 import com.github.alexliesenfeld.querydsl.jpa.hibernate.functions.AbstractJsonSQLFunction;
+
+import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 
 import java.util.List;
 
@@ -13,14 +16,11 @@ import java.util.List;
 public class JsonContainsSQLFunction extends AbstractJsonSQLFunction {
 
   @Override
-  protected void doRender(SqlAppender sb, List arguments) {
+  protected void doRender(SqlAppender sb, List<? extends SqlAstNode> arguments, SqlAstTranslator<?> walker) {
 
-    super.buildPath(sb, arguments, -1);
-    Object arg = arguments.get(arguments.size() - 1);
+    super.buildPath(sb, arguments, -1, walker);
     sb.append("@>");
-    sb.append("'");
-    sb.append(arg == null ? "null" : getSqmParameterInterpretation(arg).toString());
-    sb.append("'");
+    arguments.get(arguments.size() - 1).accept(walker);
     sb.append("::");
     sb.append(isJsonb() ? "jsonb" : "json");
   }

--- a/src/test/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/initializer/Initializer.java
+++ b/src/test/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/initializer/Initializer.java
@@ -8,7 +8,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
     @Override
     public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-        PostgreSQLContainer<?> dbContainer = new PostgreSQLContainer<>("postgres:10.6-alpine");
+        PostgreSQLContainer<?> dbContainer = new PostgreSQLContainer<>("postgres:15.3-alpine");
         dbContainer.start();
 
         TestPropertyValues.of(


### PR DESCRIPTION
- updated to spring-boot 3.1 and hibernate 6.2
- generation of full-parametric SQL queries (previous version generated mixed parametric / static queries, which required messing with Hibernate internals and moreover could lead to SQL injections)
- updated postgresql testcontainer to version 15
- minor sonarlint fixes
